### PR TITLE
Support networkx version 3.0

### DIFF
--- a/fa2/forceatlas2.py
+++ b/fa2/forceatlas2.py
@@ -245,7 +245,7 @@ class ForceAtlas2:
             or (cynetworkx and isinstance(G, cynetworkx.classes.graph.Graph))
         ), "Not a networkx graph"
         assert isinstance(pos, dict) or (pos is None), "pos must be specified as a dictionary, as in networkx"
-        M = networkx.to_scipy_sparse_matrix(G, dtype='f', format='lil', weight=weight_attr)
+        M = networkx.to_scipy_sparse_array(G, dtype='f', format='lil', weight=weight_attr)
         if pos is None:
             l = self.forceatlas2(M, pos=None, iterations=iterations)
         else:

--- a/setup.py
+++ b/setup.py
@@ -67,7 +67,7 @@ setup(
     ],
     install_requires=['numpy', 'scipy', 'tqdm'],
     extras_require={
-        'networkx': ['networkx'],
+        'networkx': ['networkx>=3.0.0'],
         'igraph': ['python-igraph']
     },
     include_package_data=True,


### PR DESCRIPTION
Method networkx.to_scipy_sparse_matrix has been deleted in the latest release.
Use networkx.to_scipy_sparse_array instead.
Tested locally on data-playground that this change works.